### PR TITLE
fix: change the port number and update keycloak.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,6 @@ app.get('/',function(req,res){
 
 app.use( keycloak.middleware( { logout: '/'} ));
 
-app.listen(8080, function () {
-  console.log('Listening at http://localhost:8080');
+app.listen(8000, function () {
+  console.log('Listening at http://localhost:8000');
 });

--- a/keycloak.json
+++ b/keycloak.json
@@ -4,5 +4,5 @@
   "ssl-required": "external",
   "resource": "keycloak-express",
   "public-client": true,
-  "use-resource-role-mappings": true
+  "confidential-port": 0
 }


### PR DESCRIPTION
# What
change the port on the express app to 8000 and update the keycloak.json 
# Why
- port 8080 on express app the same as the default port for keycloak server.
- update the keycloak.json  to work with keycloak 4.0.0beta1